### PR TITLE
Fix cartSum bug

### DIFF
--- a/assets/scripts/actions/ui.js
+++ b/assets/scripts/actions/ui.js
@@ -29,6 +29,7 @@ const addToCartSuccess = function () {
 
 const getItemToRemoveSuccess = function (data) {
   store.itemObj = data
+  store.cartSum -= store.itemObj.item.price
   const itemsArray = store.currentOrder.order.items
   const itemToRemove = data.item._id
   const newItemsArray = itemsArray.filter(i => i._id !== itemToRemove)


### PR DESCRIPTION
- cart sum was not updating when item removed from cart
- added `store.cartSum -= store.itemObj.item.price` to ui file
- this must have accidentally been deleted at some point